### PR TITLE
Revert "Bump gunicorn from 22.0.0 to 23.0.0 in the pip group across 1 directory"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.7
 Flask==3.0.0
 Flask-Cors==4.0.2
 Flask-RESTful==0.3.10
-gunicorn==23.0.0
+gunicorn==22.0.0
 idna==3.7
 importlib-metadata==6.8.0
 infisical==1.6.0


### PR DESCRIPTION
Reverts kumpeapps/Kumpe3D-API#60

## Summary by Sourcery

Bug Fixes:
- Downgrade gunicorn to the previous version to address potential compatibility issues