### PR TITLE
Revert gunicorn to version 22.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.7
 Flask==3.0.0
 Flask-Cors==4.0.2
 Flask-RESTful==0.3.10
-gunicorn==23.0.0
+gunicorn==22.0.0
 idna==3.7
 importlib-metadata==6.8.0
 infisical==1.6.0


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Reverted gunicorn to a previous version, potentially to address compatibility issues