### PR TITLE
Use PDF417 compact barcode for QR code and reduce image size

### DIFF
--- a/templates/case_label.html
+++ b/templates/case_label.html
@@ -107,7 +107,7 @@
           <div>8180 Elm Ln<br/>Rogers, AR 72756</div>
         </td>
         <td style="width:1in;" align="right" valign="top">
-          <img class="qr" src="https://quickchart.io/barcode?type=datamatrix&text={{ qr_data }}&width=50&height=50">
+          <img class="qr" src="https://quickchart.io/barcode?type=pdf417compact&text={{ qr_data }}&width=25&height=25">
         </td>
       </tr>
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Modified QR code generation to use PDF417 compact barcode type instead of datamatrix, and reduced the image size from 50x50 to 25x25 pixels