### PR TITLE
Use standard PDF417 barcode type

### DIFF
--- a/templates/case_label.html
+++ b/templates/case_label.html
@@ -103,7 +103,7 @@
           <div>8180 Elm Ln<br/>Rogers, AR 72756</div>
         </td>
         <td style="width:1in;" align="right" valign="top">
-          <img class="" src="https://quickchart.io/barcode?type=pdf417compact&text={{ qr_data }}">
+          <img class="" src="https://quickchart.io/barcode?type=pdf417&text={{ qr_data }}">
         </td>
       </tr>
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Modified the barcode generation URL to use standard PDF417 barcode type instead of compact PDF417